### PR TITLE
updating the correct path for github private key

### DIFF
--- a/Section4/Readme.md
+++ b/Section4/Readme.md
@@ -67,7 +67,7 @@ Execute these commands to upload the params to the systems manager
 aws ssm put-parameter --name "/global/airflow/webserver/flask-secret-key" --value "$(cat ./helperChart/secrets/webserver_key)" --type "SecureString"
 aws ssm put-parameter --name "/global/airflow/fernet-key" --value "$(cat ./helperChart/secrets/fernet_key)" --type "SecureString"
 aws ssm put-parameter --name "/global/airflow/github/known-hosts" --value "$(cat ./helperChart/secrets/known_hosts)" --type "SecureString"
-aws ssm put-parameter --name "/global/airflow/github/private-key" --value "$(cat ~/.ssh/id_rsa)" --type "SecureString"
+aws ssm put-parameter --name "/global/airflow/github/private-key" --value "$(cat ./helperChart/secrets/id_rsa)" --type "SecureString"
 aws ssm put-parameter --name "/global/airflow/github/dags-repo" --value "YOUR_DAGS_REPO" --type "SecureString"
 aws ssm put-parameter --name "/dev/airflow/rds/identifier" --value "YOUR_RDS_IDENTIFIER" --type "SecureString"
 aws ssm put-parameter --name "/dev/airflow/rds/password" --value "YOUR_RDS_PASSWORD" --type "SecureString"


### PR DESCRIPTION
updating the correct path for github private key. If we already have a key in ~/.ssh/id_rsa then wrong key will be uploaded to parameter store. I use an mac laptop and I already have id_rsa populated for other uses. When I follow the tutorial I created a separate key in  ./helperChart/secrets.